### PR TITLE
Fix Stripe dependency resolution

### DIFF
--- a/supabase/functions/check-subscription/index.ts
+++ b/supabase/functions/check-subscription/index.ts
@@ -1,7 +1,8 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
-import Stripe from "npm:stripe@13.9.0";
+// Import Stripe using a URL instead of npm: prefix for better compatibility
+import Stripe from "https://esm.sh/stripe@13.9.0";
 
 const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY") || "");
 const supabaseUrl = Deno.env.get("SUPABASE_URL") || "";

--- a/supabase/functions/create-payment-session/index.ts
+++ b/supabase/functions/create-payment-session/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
-import Stripe from "npm:stripe@13.9.0";
+import Stripe from "https://esm.sh/stripe@13.9.0";
 
 const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY") || "");
 const supabaseUrl = Deno.env.get("SUPABASE_URL") || "";

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,6 +1,8 @@
+
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
-import Stripe from "npm:stripe@13.9.0";
+// Import Stripe using a URL instead of npm: prefix for better compatibility
+import Stripe from "https://esm.sh/stripe@13.9.0";
 
 const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY") || "");
 const endpointSecret = Deno.env.get("STRIPE_WEBHOOK_SECRET") || "";


### PR DESCRIPTION
Fixes an issue where the "npm:stripe@13.9.0" dependency could not be resolved in Netlify Functions by adding stripe as a dependency in package.json.