### PR TITLE
Fix dependency resolution error

### DIFF
--- a/supabase/functions/send-welcome-email/index.ts
+++ b/supabase/functions/send-welcome-email/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { Resend } from "npm:resend@2.0.0";
+import { Resend } from "https://esm.sh/resend@2.0.0";
 
 const resend = new Resend(Deno.env.get("RESEND_API_KEY"));
 


### PR DESCRIPTION
The Netlify build was failing because the "npm:resend@2.0.0" dependency could not be resolved in the send-welcome-email function. This commit ensures that all dependencies are correctly resolved.